### PR TITLE
Norm/minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,7 @@ embed: tsc
 	GOOS="" GOARCH="" go run web/embed/main.go web/embed/mappings.yml
 
 tsc:
-	cd web && npm install
-	npx tsc --project web/tsconfig.json
+	cd web && npm install && npx tsc --project tsconfig.json
 
 clean:
 	rm -rf $(APP_NAME) releases

--- a/TODO
+++ b/TODO
@@ -5,6 +5,6 @@
 > 
 > Current status. Kingpin is largely feature stable. There hasn't been a need to add new features in a while, but there are some bugs that should be fixed.
 > 
-> Why? I no longer use Kingpin personally (I now use kong). Rather than leave the project in a limbo of people filing issues and wondering why they're not being worked on, I believe this notice will more clearly set expectations.
+> **Why? I no longer use Kingpin personally (I now use kong). Rather than leave the project in a limbo of people filing issues and wondering why they're not being worked on, I believe this notice will more clearly set expectations.**
 
 2. Do we find a supported ansi interface?

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/doomsday-project/doomsday
 
-go 1.21.6
+go 1.22
 
 toolchain go1.22.4
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@types/jquery": "^3.5.1",
         "@types/sizzle": "^2.3.3",
-        "typescript": "^5.5.2"
+        "typescript": "^5.5.3"
       }
     },
     "node_modules/@types/jquery": {
@@ -24,9 +24,9 @@
       "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
     },
     "node_modules/typescript": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
-      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -52,9 +52,9 @@
       "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
     },
     "typescript": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
-      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew=="
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ=="
     }
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,6 @@
   "dependencies": {
     "@types/jquery": "^3.5.1",
     "@types/sizzle": "^2.3.3",
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.3"
   }
 }


### PR DESCRIPTION
1. using the go mod tidy output for the go.mod go version information
2. get npm install typescript to work correctly from the web directory instead of the repo home directory